### PR TITLE
Add back 3 removed unrelated note lines

### DIFF
--- a/windows/security/threat-protection/windows-defender-antivirus/configure-extension-file-exclusions-windows-defender-antivirus.md
+++ b/windows/security/threat-protection/windows-defender-antivirus/configure-extension-file-exclusions-windows-defender-antivirus.md
@@ -47,10 +47,10 @@ This means the exclusion lists have the following characteristics:
 - Folder exclusions will apply to all files and folders under that folder, unless the subfolder is a reparse point. Reparse point subfolders must be excluded separately.
 - File extensions will apply to any file name with the defined extension if a path or folder is not defined.
 
-
 >[!IMPORTANT]
+>
 >The use of wildcards such as the asterisk (\*) will alter how the exclusion rules are interpreted. See the [Use wildcards in the file name and folder path or extension exclusion lists](#use-wildcards-in-the-file-name-and-folder-path-or-extension-exclusion-lists) section for important information about how wildcards work.
-
+>
 >You cannot exclude mapped network drives. You must specify the actual network path.
 >Folders that are reparse points that are created after the Windows Defender Antivirus service starts and that have been added to the exclusion list will not be included. You must restart the service (by restarting Windows) for new reparse points to be recognized as a valid exclusion target.
 
@@ -58,9 +58,9 @@ To exclude files opened by a specific process, see [Configure and validate exclu
 
 The exclusions apply to [scheduled scans](scheduled-catch-up-scans-windows-defender-antivirus.md), [on-demand scans](run-scan-windows-defender-antivirus.md), and [real-time protection](configure-real-time-protection-windows-defender-antivirus.md).
 
-
 >[!IMPORTANT]
 >Exclusion list changes made with Group Policy **will show** in the lists in the [Windows Security app](windows-defender-security-center-antivirus.md#exclusions).
+>
 >Changes made in the Windows Security app **will not show** in the Group Policy lists.
 
 By default, local changes made to the lists (by users with administrator privileges, including changes made with PowerShell and WMI) will be merged with the lists as defined (and deployed) by Group Policy, Configuration Manager, or Intune. The Group Policy lists will take precedence in case of conflicts.


### PR DESCRIPTION
Adding back the 3 lines you removed outside of the added note.

One of the last line changes was correctly placed, but
missing the > character to keep the block together.

Ref. https://github.com/MicrosoftDocs/windows-itpro-docs/pull/3414